### PR TITLE
[DOCS-237] Added tutorial file to here from rawlingsj git repo

### DIFF
--- a/springboot-tutorial-index.html
+++ b/springboot-tutorial-index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>CloudBees Application for Kubernetes CD</title>
+  </head>
+  <body bgcolor=white>
+
+    <table border="0" cellpadding="10">
+      <tr>
+        <td>
+          <img height="300" width="300" src="https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/e6d33452976bdab9489b63153c2e7f93312a9af3/images/core.png">
+        </td>
+        <td>
+          <h1>Kube CD</h1>
+        </td>
+      </tr>
+    </table>
+
+  </body>
+</html>


### PR DESCRIPTION
Copied `index.html` file referred to in https://go.cloudbees.com/docs/cloudbees-core/kubernetes-cd-tutorials/spring-boot-tutorial/ to here.

This impacts step #13:
```$ curl -o src/main/resources/static/index.html https://gist.githubusercontent.com/rawlingsj/ae624d06fd411e321ade0a180c973a13/raw/3b608e7e5c5dda4f76f33e834f2a199877fbe1bd/index.html```

Original content:
https://gist.githubusercontent.com/rawlingsj/ae624d06fd411e321ade0a180c973a13/raw/3b608e7e5c5dda4f76f33e834f2a199877fbe1bd/index.html

@tfoxnc Once I know this works for you and everything looks ok, I'll fix the actual text in the tutorial and test it.
