### PR TITLE
[NGPIPELINE-523] Change out remote for serverUrl for Bitbucket MBPs

### DIFF
--- a/pipeline-template-examples/demos/multibranch-bitbucket-org/README.md
+++ b/pipeline-template-examples/demos/multibranch-bitbucket-org/README.md
@@ -7,7 +7,7 @@ This example shows how to add authentication to Bitbucket.org. The developer wil
 multibranch:
   branchSource:
     bitbucket:
-      remote: https://bitbucket.org
+      serverUrl: https://bitbucket.org
       repoOwner: myCompany
       repository: ${repoName}
       credentialsId: my-team-bitbucket-credentials

--- a/pipeline-template-examples/demos/multibranch-bitbucket-server/README.md
+++ b/pipeline-template-examples/demos/multibranch-bitbucket-server/README.md
@@ -7,7 +7,7 @@ This example shows how to add authentication to a Bitbucket server. The develope
 multibranch:
   branchSource:
     bitbucket:
-      remote: https://bitbucket.example.com
+      serverUrl: https://bitbucket.example.com
       repoOwner: myCompany
       repository: ${repoName}
       credentialsId: my-team-bitbucket-credentials


### PR DESCRIPTION
# Summary

This is a pull request to accompany [cbn-site PR 1842](https://github.com/cloudbees/cbn-site/pull/1842).

# Backstory
[CORE-1897](https://cloudbees.atlassian.net/browse/CORE-1897) was opened because a customer followed our documentation, and had a problem. They discovered that setting the `remote` field on a template for multibranch projects hosted on Bitbucket servers did not work. And in fact, it was defaulting to https://bitbucket.org. I opened NGPIPELINE-523 to fix what we thought at the time was a bug, but the correct fix turned out to be this documentation change.

# Examples
Below is a sample `template.yaml` which will not work, because the `remote` field name is the wrong name.

```yaml
version: 1
type: pipeline-template
templateType: MULTIBRANCH

name: KARL-MADE-THIS
description: Simple Java App With Maven
multibranch:
  branchSource:
    bitbucket:
      remote: https://bitbucket.beescloud.com
      repoOwner: KARL
      repository: catalog-repo
      credentialsId: dev1bbs
```

And here is a corrected version, which works correctly:

```yaml
version: 1
type: pipeline-template
templateType: MULTIBRANCH

name: KARL-MADE-THIS
description: Simple Java App With Maven
multibranch:
  branchSource:
    bitbucket:
      serverUrl: https://bitbucket.beescloud.com
      repoOwner: KARL
      repository: catalog-repo
      credentialsId: dev1bbs
```
