### PR TITLE
CBCI Master Provisioning CasC sample is updated

### DIFF
--- a/cloudbees-ci/configuration-as-code-examples/cloud-platform-master-provisioning-plugin/configuration-as-code.yml
+++ b/cloudbees-ci/configuration-as-code-examples/cloud-platform-master-provisioning-plugin/configuration-as-code.yml
@@ -1,9 +1,9 @@
-unclassified:
+masterProvisioning:
   dockerImageDefinitionConfiguration:
     images:
       - imageTag: "cloudbees/cloudbees-core-mm"
         name: "latest"
-  kubernetesMasterProvisioning:
+  kubernetes:
     clusterEndpoints:
       - id: "default"
         jenkinsUrl: "http://host.docker.internal:8080/jenkins"


### PR DESCRIPTION
Based on the release notes of 2.235.4.1[1] the structure has changed, so the sample needs to be updated to still be compatible with 2.235.4.1 and newer. I didn't test it personally but a customer on support case 189652 had an error because of this change and once I suggest modification like this they resolved the problem.

1: https://docs.cloudbees.com/docs/release-notes/latest/cloudbees-ci/modern-cloud-platforms/2.235.4.1#_feature_enhancements