### PR TITLE
[CBSDA-211] Add JCasC example for CloudBees Plugin Usage Analyzer Plugin

### DIFF
--- a/cloudbees-ci/configuration-as-code-examples/cloudbees-plugin-usage-plugin/configuration-as-code.yml
+++ b/cloudbees-ci/configuration-as-code-examples/cloudbees-plugin-usage-plugin/configuration-as-code.yml
@@ -1,3 +1,3 @@
 tool:
   cloudbeesPluginUsageAnalyzer:
-    enabled: true
+    enabled: false

--- a/cloudbees-ci/configuration-as-code-examples/cloudbees-plugin-usage-plugin/configuration-as-code.yml
+++ b/cloudbees-ci/configuration-as-code-examples/cloudbees-plugin-usage-plugin/configuration-as-code.yml
@@ -1,0 +1,3 @@
+tool:
+  cloudbeesPluginUsageAnalyzer:
+    enabled: true


### PR DESCRIPTION
CloudBees Plugin Usage Analyzer Plugin 2.7 (which will be released soon) introduces a configuration option to disable the periodic usage scans. This PR adds an example showing how that option can be configured using JCasC.