### PR TITLE
update CD demo values to work with CD version 10.1

### DIFF
--- a/cloudbees-cd/kubernetes/cloudbees-cd-demo.yaml
+++ b/cloudbees-cd/kubernetes/cloudbees-cd-demo.yaml
@@ -31,13 +31,17 @@ server:
 zookeeper:
   enabled: false
 
+# clusteredMode has to be false to be able to use mariadb
+clusteredMode: false
+
 # Install mariadb chart for demo mode 
 # and create a database and user for Flow to use. 
 # Note that the database user name and password 
-# specified in the `initdbScripts` section must
+# specified in the `mariadb.db.user` and `mariadb.rootUser.password` value must
 # match the values in the `database` section below.
 
 mariadb:
+  enabled: true
   fullnameOverride: mariadb
   replication:
     enabled: false
@@ -45,14 +49,10 @@ mariadb:
     enabled: true
   volumePermissions:
     enabled: true
-  initdbScripts:
-    demo-db.sql: |-
-      CREATE DATABASE IF NOT EXISTS demo CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-      CREATE DATABASE IF NOT EXISTS demo_upgrade CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-      CREATE USER 'flow'@'%' IDENTIFIED BY 'flow_pass';
-      GRANT ALL PRIVILEGES ON demo.* TO 'flow'@'%';
-      GRANT ALL PRIVILEGES ON demo_upgrade.* TO 'flow'@'%';
-      FLUSH PRIVILEGES;
+  db:
+    user: "flow"
+  rootUser:
+    password: "flow_pass"
 
 database:
   dbName: "demo"


### PR DESCRIPTION
Starting in CD version 10.1, you must pass `clusteredMode: false` to be able to use MariaDB.

If you don't have that set, the helm install currently fails with:

```
Error: execution error at (cloudbees-flow/templates/server-job-init.yaml:92:3): .database.dbType has to be one of mysql oracle sqlserver
```

Also new with 10.1, `mariadb.initdbScripts` is no longer used, you would instead use `mariadb.initdbScriptsConfigMap`, but we don't need to specify them as it's now part of the chart, we just need to pass the user and password (if the password is an empty string, a random 10 character password will be used).

I've tested these updated values to work with helm chart version:

```
NAME                            CHART VERSION   APP VERSION     DESCRIPTION                          
cloudbees/cloudbees-flow        2.8.0           10.1.0.145850   A Helm chart for CloudBees Flow
```