### PR TITLE
Increasing the limit ressources for Flow server

### DIFF
--- a/cloudbees-cd/kubernetes/cloudbees-cd-demo.yaml
+++ b/cloudbees-cd/kubernetes/cloudbees-cd-demo.yaml
@@ -23,9 +23,9 @@ storage:
 server:
   resources:
     limits:
-      cpu: 1.5
+      cpu: 3
     requests:
-      cpu: 0.5
+      cpu: 2
 
 # Install mariadb chart for demo mode 
 # and create a database and user for Flow to use. 


### PR DESCRIPTION
It seems that the flow server needs at least 2 CPU to run (now?) cause I tried to start a local cluster with this configuration file and I have this error on the commander.log : "java.lang.RuntimeException: Unable to start with only one processor, at least two are required"
I propose 3 cpu for limits but maybe limit at 2 and request 2 is suffisant for a demo configuration.