### PR TITLE
BEE-33777 [DOCS] Validate JCasC support

### DIFF
--- a/cloudbees-ci/configuration-as-code-examples/cloudbees-pipeline-explorer-plugin/configuration-as-code.yml
+++ b/cloudbees-ci/configuration-as-code-examples/cloudbees-pipeline-explorer-plugin/configuration-as-code.yml
@@ -1,0 +1,5 @@
+unclassified:
+  cloudbeesPipelineExplorer:
+    enabled: false
+    autoPollingEnabled: true
+    autoPollingIntervalSeconds: 15


### PR DESCRIPTION
Added the CloudBees Pipeline Explorer plugin to the Tier 1 and Tier 2 plugins support for CasC table.

https://docs.cloudbees.com/docs/cloudbees-common/latest/supported-platforms/cloudbees-ci-cloud#_tier_1_and_tier_2_plugins_support_for_configuration_as_code