### PR TITLE
[OPS-17066] recommend e2-standard instance family

### DIFF
--- a/cloudbees-cd/kubernetes/gke/demo.md
+++ b/cloudbees-cd/kubernetes/gke/demo.md
@@ -12,7 +12,7 @@ Be sure to follow the security policies and rules of your organization.
   # Number of nodes in the cluster, 2 is enough for demo purposes
   GKE_CLUSTER_NUM_NODES=<gke-cluster-number-of-nodes>   # e.g. GKE_CLUSTER_NUM_NODES=2
   # Machine type for the GKE cluster nodes, e2-standard-4 is enough for demo purposes
-  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=-e2-standard-4
+  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=e2-standard-4
   HELM_RELEASE=<cloudbees-cd-helm-release>              # e.g. HELM_RELEASE=cd-demo
   NAMESPACE=<cloudbees-cd-namespace>                    # e.g. NAMESPACE=cd-demo
   ```  

--- a/cloudbees-cd/kubernetes/gke/demo.md
+++ b/cloudbees-cd/kubernetes/gke/demo.md
@@ -11,8 +11,8 @@ Be sure to follow the security policies and rules of your organization.
   GKE_CLUSTER_NAME=<gke-cluster-name>                   # e.g. GKE_CLUSTER_NAME=gke-cd-demo
   # Number of nodes in the cluster, 2 is enough for demo purposes
   GKE_CLUSTER_NUM_NODES=<gke-cluster-number-of-nodes>   # e.g. GKE_CLUSTER_NUM_NODES=2
-  # Machine type for the GKE cluster nodes, n1-standard-4 is enough for demo purposes
-  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=n1-standard-4
+  # Machine type for the GKE cluster nodes, e2-standard-4 is enough for demo purposes
+  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=-e2-standard-4
   HELM_RELEASE=<cloudbees-cd-helm-release>              # e.g. HELM_RELEASE=cd-demo
   NAMESPACE=<cloudbees-cd-namespace>                    # e.g. NAMESPACE=cd-demo
   ```  

--- a/cloudbees-cd/kubernetes/gke/prod.md
+++ b/cloudbees-cd/kubernetes/gke/prod.md
@@ -15,8 +15,8 @@ Be sure to follow the security policies and rules of your organization.
   GKE_CLUSTER_NAME=<gke-cluster-name>                   # e.g. GKE_CLUSTER_NAME=gke-cd-prod
   # Number of nodes in the cluster, 3 is enough for production purposes
   GKE_CLUSTER_NUM_NODES=<gke-cluster-number-of-nodes>   # e.g. GKE_CLUSTER_NUM_NODES=3
-  # Machine type for the GKE cluster nodes, n1-standard-8 is enough for production purposes
-  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=n1-standard-8
+  # Machine type for the GKE cluster nodes, e2-standard-8 is enough for production purposes
+  GKE_CLUSTER_MACHINE_TYPE=<gke-cluster-machine-type>   # e.g. GKE_CLUSTER_MACHINE_TYPE=e2-standard-8
   HELM_RELEASE=<cloudbees-cd-helm-release>              # e.g. HELM_RELEASE=cd-prod
   NAMESPACE=<cloudbees-cd-namespace>                    # e.g. NAMESPACE=cd-prod
   ```


### PR DESCRIPTION
Suggest people use e2-standard in preference to n1-standard for cost reasons

Ops team has already migrated our own CBCI clusters to e2-standard, and now we are recommending the same to others