### PR TITLE
Create example for the `cloudbees-cache-step` plugin

### DIFF
--- a/cloudbees-ci/configuration-as-code-examples/cloudbees-cache-step
+++ b/cloudbees-ci/configuration-as-code-examples/cloudbees-cache-step
@@ -1,0 +1,9 @@
+workspaceCache:
+    cacheManager:
+      googleCloudStorage:
+        bucket: "bucket-name"
+        credentialsId: "cred-id"
+        prefix: "prefix"
+    jobExcludes: "excluded-jobs"
+    jobIncludes: "included-jobs"
+  


### PR DESCRIPTION
Created an example for the `cloudbees-cache-step` plugin. Moved from a private repo.:

link:https://github.com/cloudbees/cloudbees-cache-step-plugin/blob/5a11a8a16f0abcd0e8981c86dc52c54b7dddb4d7/cloudbees-google-cloud-storage-cache/src/test/resources/com/cloudbees/cache/casc/configuration-as-code.yaml[]