### PR TITLE
BEE-36818 [DOCS] Remove `Persistence.ExistingClaim` from migration guides

### DIFF
--- a/helm-custom-value-file-examples/migration-values-example.yaml
+++ b/helm-custom-value-file-examples/migration-values-example.yaml
@@ -14,5 +14,3 @@ OperationsCenter:
       Enable: false
       SecretName: core-example-com-tls
       Host: jenkins.cluster.local
-
-

--- a/helm-custom-value-file-examples/migration-values-example.yaml
+++ b/helm-custom-value-file-examples/migration-values-example.yaml
@@ -15,6 +15,4 @@ OperationsCenter:
       SecretName: core-example-com-tls
       Host: jenkins.cluster.local
 
-# Do not change these values. They are all set for migrating CloudBees CI. 
-Persistence:
-  ExistingClaim: 'jenkins-home-cjoc-0' 
+

--- a/helm-custom-value-file-examples/openshift-migration-values-example.yaml
+++ b/helm-custom-value-file-examples/openshift-migration-values-example.yaml
@@ -19,7 +19,4 @@ OperationsCenter:
     Project:
       name: myproject
 
-# Do not change these values. They are all set for migrating CloudBees Core.
-Persistence:
-  ExistingClaim: 'jenkins-home-cjoc-0'
 

--- a/helm-custom-value-file-examples/openshift-migration-values-example.yaml
+++ b/helm-custom-value-file-examples/openshift-migration-values-example.yaml
@@ -18,5 +18,3 @@ OperationsCenter:
     # Update this with the openshift project your are using.
     Project:
       name: myproject
-
-


### PR DESCRIPTION
Removed references to `Persistence.ExistingClaim` from the migration guides.