### PR TITLE
release-2026.03-k8s

### DIFF
--- a/cloudbees-cd/kubernetes/cloudbees-cd-agent-defaults.yaml
+++ b/cloudbees-cd/kubernetes/cloudbees-cd-agent-defaults.yaml
@@ -9,7 +9,7 @@ images:
   ## The `imageRepository` in the `images.registry` to pull the agent image from.
   imageRepository: "cbflow-agent"
   ## CloudBees CD/RO flow-server image tag to pull.
-  tag: "2025.09.0.181816_3.2.191_20250916"
+  tag: "2026.03.0.185227_3.2.235_20260321"
 
   ## The image pull policy to use:
   pullPolicy: IfNotPresent

--- a/cloudbees-cd/kubernetes/cloudbees-cd-defaults.yaml
+++ b/cloudbees-cd/kubernetes/cloudbees-cd-defaults.yaml
@@ -24,7 +24,7 @@ images:
   registry: "docker.io/cloudbees"
 
   ## CloudBees CD/RO flow-server image tag to pull.
-  tag: "2025.09.0.181816_3.2.191_20250916"
+  tag: "2026.03.0.185227_3.2.235_20260321"
 
   ## The image pull policy to use.
   pullPolicy: IfNotPresent
@@ -1307,7 +1307,7 @@ zookeeper:
     ## Container repository to pull ZooKeeper image from.
     repository: docker.io/cloudbees/cbflow-tools
     ## Zookeeper image tag to pull.
-    tag: "2025.09.0.181816_3.2.191_20250916"
+    tag: "2026.03.0.185227_3.2.235_20260321"
     ## Added Image repository for global values support
     imageRepository: cbflow-tools
   fullnameOverride: zookeeper

--- a/cloudbees-cd/kubernetes/values.yaml
+++ b/cloudbees-cd/kubernetes/values.yaml
@@ -1,4 +1,3 @@
-
 ### Global  configurations section
 ### ---------------------------------------------
 ## Please, note that this will override the parameters, including sub-charts,
@@ -25,7 +24,7 @@ images:
   registry: "docker.io/cloudbees"
 
   ## CloudBees CD/RO flow-server image tag to pull.
-  tag: "2025.09.0.181816_3.2.191_20250916"
+  tag: "2026.03.0.185227_3.2.235_20260321"
 
   ## The image pull policy to use.
   pullPolicy: IfNotPresent
@@ -35,10 +34,10 @@ images:
   ## `imagePullSecrets: <secret-name>`
   imagePullSecrets:
 
-  ## (OPTIONAL) Create an array of `imagePullSecrets` containing private registry credentials.
-  ## when you have one or more secrets to use when pulling images.
-  ## NOTE: Only one instance of `imagePullSecrets:` can be present.
-  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+   ## (OPTIONAL) Create an array of `imagePullSecrets` containing private registry credentials.
+   ## when you have one or more secrets to use when pulling images.
+   ## NOTE: Only one instance of `imagePullSecrets:` can be present.
+   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 #  imagePullSecrets:
 #    - name: "docker-registry"
 
@@ -79,21 +78,21 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "4000"
     nginx.ingress.kubernetes.io/proxy-stream-timeout: "4000"
 
-    ## If you are using EKS with ALB, enable the follow annotations:
-  #    alb.ingress.kubernetes.io/scheme: internet-facing
-  #    alb.ingress.kubernetes.io/certificate-arn: "<acm certificate arn>"
+     ## If you are using EKS with ALB, enable the follow annotations:
+#    alb.ingress.kubernetes.io/scheme: internet-facing
+#    alb.ingress.kubernetes.io/certificate-arn: "<acm certificate arn>"
 
 
   ## Set to the same value as `ingress-nginx.controller.ingressClassResource.name` if enabled.
   class: flow-ingress
-    ## If using EKS and need to deploy ALB load balancer with alb controller enabled, set to `alb`.
-    #  class: alb
+  ## If using EKS and need to deploy ALB load balancer with alb controller enabled, set to `alb`.
+#  class: alb
 
 
-    ## Certificate for CloudBees flow-web ingress.
-  ## You can also set using `helm install --set-file`.
-  #   ingress.certificate.key=path/to/key` `--set-file
-  #   ingress.certificate.crt=path/to/certificate`
+   ## Certificate for CloudBees flow-web ingress.
+   ## You can also set using `helm install --set-file`.
+#   ingress.certificate.key=path/to/key` `--set-file
+#   ingress.certificate.crt=path/to/certificate`
 
   ## Example structure to configure an ingress certificate for TLS.
   certificate:
@@ -118,6 +117,7 @@ ingress:
     # - Allow: Allow both HTTP and HTTPS traffic.
     # - Redirect: Redirect HTTP traffic to HTTPS.
     insecureEdgeTerminationPolicy: Redirect
+
 
 
 
@@ -146,6 +146,17 @@ server:
   ## The default loglevel for cbflow-server.
   logLevel: DEBUG
 
+  ## Complete logging configuration for logging-local.properties.
+  ## If provided, this will override the default logLevel-based configuration.
+  ## This allows you to configure multiple loggers with different log levels.
+  loggingConfig: ""
+  ## Example usage:
+  # loggingConfig: |
+  #   com.electriccloud=DEBUG
+  #   com.electriccloud.commander=INFO
+  #   org.apache=WARN
+  #   com.zaxxer.hikari=DEBUG
+
   zk:
     host: zookeeper
     port: 2181
@@ -166,6 +177,24 @@ server:
   tolerations: []
   affinity: {}
 
+  ## topologySpreadConstraints: Distribute pods across topology domains (e.g., zones)
+  ## For multi-AZ deployments, configure topologySpreadConstraints to spread pods
+  ## across availability zones. Example:
+  ##
+  ## topologySpreadConstraints:
+  ##   - maxSkew: 1
+  ##     topologyKey: topology.kubernetes.io/zone
+  ##     whenUnsatisfiable: DoNotSchedule
+  ##     labelSelector:
+  ##       matchLabels:
+  ##         app: flow-server
+  ##
+  ## Refer to: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+
+  ## The terminationGracePeriodSeconds for the cbflow-server pod.
+  terminationGracePeriodSeconds: 30
+
   ## Kubernetes Liveness Probes:
   livenessProbe:
     initialDelaySeconds: 90
@@ -175,7 +204,7 @@ server:
 
   ## Kubernetes Readiness Probes:
   readinessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 90
     periodSeconds: 10
     failureThreshold: 10
     timeoutSeconds: 10
@@ -187,23 +216,34 @@ server:
   ## Specify where your additional volumes are mounted in the cbflow-server container.
   additionalVolumeMounts: []
 
+  ## Specify additional init containers for cbflow-server.
+  ## Init containers run before the main container starts and are useful for
+  ## setup tasks, pre-configuration, or waiting for dependencies.
+  additionalInitContainers: []
+#   - name: init-container-name
+#     image: busybox:latest
+#     command:
+#       - sh
+#       - -c
+#       - echo "Initialization complete"
+
   ## Specify additional containers to mount for cbflow-server.
   additionalContainers:
-  #     - name: container-name
-  #       image: image-version
-  #       command:
-  #         - "/container-command"
+#     - name: container-name
+#       image: image-version
+#       command:
+#         - "/container-command"
 
   ## Specify any additional environment variables to set for cbflow-server.
   extraEnvs: []
-  # extraEnvs:
-  #   - name: FOO
-  #     value: "BAR"
-  #   - name: FOO
-  #     valueFrom:
-  #       secretKeyRef:
-  #         key: FOO
-  #         name: secret-resource
+# extraEnvs:
+#   - name: FOO
+#     value: "BAR"
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
 
   ## Enable or disable sending telemetry data to CloudBees.
   ## NOTE: This option only works for the initial installation of the cbflow-server.
@@ -218,12 +258,31 @@ server:
     ## server LoadBalancer service annotations for
     ## creating internal LoadBalancer on GCP or AWS.
     annotations:
-  #      networking.gke.io/load-balancer-type: "Internal"
-  #      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+#      networking.gke.io/load-balancer-type: "Internal"
+#      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 
   ## Enable or disable creating init container for volume permissions for cbflow-server.
   volumesPermissionsInitContainer:
     enabled: true
+
+  ## Logs storage configuration for cbflow-server
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs if not specified)
+    path: /opt/cbflow/logs
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Enable subPath expression for server-specific directories (useful in clustered mode)
+    useSubPathExpr: false
+    ## Custom subPath expression for server (defaults to $(POD_NAME) when useSubPathExpr: true)
+    subPathExpr: "$(POD_NAME)"
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-server-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
 
   ## Horizontal Pod Autoscaling configuration for cbflow-server.
   ## This is only supported when `clusteredMode:true`.
@@ -233,6 +292,13 @@ server:
     maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
     templates: []
     ## Specify custom or additional autoscaling metrics.
     ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
@@ -243,6 +309,37 @@ server:
 #         target:
 #           type: AverageValue
 #           averageValue: 10000m
+  ## Custom labels for CD/RO flow-server pods
+  customLabels: {}
+
+  ## Deployment strategy configuration
+  ## type: Recreate (default, safe for database-connected services) or RollingUpdate
+  ## WARNING: RollingUpdate for server requires:
+  ##   - Multiple replicas (clusteredMode: true)
+  ##   - Database schema compatibility between versions
+  ##   - Tested agent connection handling during rolling updates
+  ## Recreate strategy is recommended for production upgrades.
+  strategy:
+    type: Recreate
+    rollingUpdate:
+      ## Maximum number of pods that can be created above replicas during update
+      maxSurge: 1
+      ## Maximum number of pods that can be unavailable during update
+      maxUnavailable: 0
+
+  ## Custom configuration files to be mounted in /custom-config directory.
+  ## Files can be provided using `--set-file server.customConfig.<filename>="path/to/file"`
+  ## Example: `--set-file server.customConfig.passkey="./passkey"`
+  ## Alternatively, use an existing Secret managed by a third-party system.
+  customConfig:
+    ## Name of an existing Secret to use instead of creating one from customConfig values.
+    ## The Secret should contain keys for each file to be mounted (e.g., passkey, keystore, commander.properties).
+    ## When set, the chart will not create the flow-server-custom-config-files Secret.
+    ## All keys in the secret will be automatically copied to /custom-config/ by the startup script.
+    ## Example:
+    ##   existingSecret: "vault-managed-flow-config"
+    ## This will mount all keys from the secret and copy them to /custom-config/<keyname>.
+    existingSecret:
 
 jobInit:
   annotations:
@@ -252,6 +349,7 @@ jobInit:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
 
   ## Specify the resources to request for this component.
   resources:
@@ -262,11 +360,40 @@ jobInit:
       cpu: 2
       memory: 6Gi
 
-  ## Kubernetes Liveness Probes:
-  livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    timeoutSeconds: 10
+  ## Logs storage configuration for cbflow-job-init
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs if not specified)
+    path: /opt/cbflow/logs
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Enable subPath expression for job-init-specific directories
+    useSubPathExpr: false
+    ## Custom subPath expression for job-init (defaults to $(POD_NAME) when useSubPathExpr: true)
+    subPathExpr: "$(POD_NAME)"
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-job-init-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
+
+  ## Custom labels for CD/RO job-init pods
+  customLabels: {}
+  ## Specify additional volumes to mount in the cbflow-job init server.
+  additionalVolumes: []
+
+  ## Specify where your additional volumes are mounted in the cbflow-job init server.
+  additionalVolumeMounts: []
+
+  ## Specify additional containers to mount for cbflow-job init server.
+  additionalContainers:
+#     - name: container-name
+#       image: image-version
+#       command:
+#         - "/container-command"
+
 
 ### --------------------------------------------
 ### Flow web server configuration section
@@ -299,17 +426,18 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
 
   ## Additional environment variables to set for cbflow-web.
   extraEnvs: []
-  # extraEnvs:
-  #   - name: FOO
-  #     value: "BAR"
-  #   - name: FOO
-  #     valueFrom:
-  #       secretKeyRef:
-  #         key: FOO
-  #         name: secret-resource
+# extraEnvs:
+#   - name: FOO
+#     value: "BAR"
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
 
   ## Enable shared plugin volume mount (PVC) on flow-web pods.
   ## Mounts empty dir instead if `sharedPluginsEnabled` is false.
@@ -324,19 +452,19 @@ web:
 
   ## Specify additional containers to mount for cbflow-web.
   additionalContainers:
-  #       - name: container-name
-  #         image: image-version
-  #         command:
-  #           - "/container-command"
+#       - name: container-name
+#         image: image-version
+#         command:
+#           - "/container-command"
 
-  ## Kubernetes Liveness Probes:
+## Kubernetes Liveness Probes:
   livenessProbe:
     initialDelaySeconds: 10
     periodSeconds: 60
     timeoutSeconds: 10
     failureThreshold: 3
 
-  ## Kubernetes Readiness Probes:
+## Kubernetes Readiness Probes:
   readinessProbe:
     initialDelaySeconds: 10
     periodSeconds: 5
@@ -351,6 +479,13 @@ web:
     maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
     templates: []
     ## Specify custom or additional autoscaling metrics.
     ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
@@ -362,9 +497,38 @@ web:
 #           type: AverageValue
 #           averageValue: 10000m
 
-
   ## Custom labels for CD/RO web pods
   customLabels: {}
+
+  ## Deployment strategy configuration
+  ## type: Recreate (default, safer for web server state) or RollingUpdate
+  ## WARNING: RollingUpdate for web requires:
+  ##   - Multiple replicas
+  ##   - Proper session affinity configuration in ingress
+  ##   - Testing of UI state during rolling updates
+  ## Recreate strategy is recommended for production upgrades.
+  strategy:
+    type: Recreate
+    rollingUpdate:
+      ## Maximum number of pods that can be created above replicas during update
+      maxSurge: 1
+      ## Maximum number of pods that can be unavailable during update
+      maxUnavailable: 0
+
+  ## Logs storage configuration for cbflow-web
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs if not specified)
+    path: /opt/cbflow/logs
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-web-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
 
   ## Enable TLS termination at the CloudBees Flow web server.
   certificate:
@@ -413,6 +577,16 @@ repository:
   ## The default loglevel for cbflow-repository.
   logLevel: DEBUG
 
+  ## Complete logging configuration for logging-local.properties.
+  ## If provided, this will override the default logLevel-based configuration.
+  ## This allows you to configure multiple loggers with different log levels.
+  loggingConfig: ""
+  ## Example usage:
+  # loggingConfig: |
+  #   com.electriccloud=DEBUG
+  #   com.electriccloud.commander=INFO
+  #   org.apache=WARN
+
   ## Interpreted as if passed to the CloudBees ecconfigure utility within the container.
   ecconfigure: "--repositoryInitMemoryMB=512 --repositoryMaxMemoryMB=1024"
 
@@ -428,17 +602,18 @@ repository:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
 
   ## Additional environment variables to set for cbflow-repository.
   extraEnvs: []
-  #  extraEnvs:
-  #    - name: FOO
-  #      value: "BAR"
-  #    - name: FOO
-  #      valueFrom:
-  #        secretKeyRef:
-  #          key: FOO
-  #          name: secret-resource
+#  extraEnvs:
+#    - name: FOO
+#      value: "BAR"
+#    - name: FOO
+#      valueFrom:
+#        secretKeyRef:
+#          key: FOO
+#          name: secret-resource
 
   ## Requires `repository.expose.enable: true` and port `8200` to be open and externally exposed.
   ## Creates extra Kubernetes service with type LoadBalancer.
@@ -447,14 +622,29 @@ repository:
     ## repository LoadBalancer service annotations for
     ## creating internal LoadBalancer on GCP or AWS.
     annotations:
-  #      networking.gke.io/load-balancer-type: "Internal"
-  #      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+#      networking.gke.io/load-balancer-type: "Internal"
+#      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 
 
 
   ## Enable or disable creating init container for volume permissions for cbflow-repository.
   volumesPermissionsInitContainer:
     enabled: true
+
+  ## Logs storage configuration for cbflow-repository
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs/repository if not specified)
+    path: /opt/cbflow/logs/repository
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-repository-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
 
   ## Specify additional volumes to mount in the cbflow-repository container.
   additionalVolumes: []
@@ -464,19 +654,19 @@ repository:
 
   ## Specify additional containers to mount for cbflow-repository.
   additionalContainers:
-  #     - name: container-name
-  #       image: image-version
-  #       command:
-  #         - "/container-command"
+#     - name: container-name
+#       image: image-version
+#       command:
+#         - "/container-command"
 
-  ## Kubernetes Liveness Probes:
+## Kubernetes Liveness Probes:
   livenessProbe:
     initialDelaySeconds: 120
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
 
-  ## Kubernetes Readiness Probes:
+## Kubernetes Readiness Probes:
   readinessProbe:
     initialDelaySeconds: 120
     periodSeconds: 5
@@ -491,6 +681,13 @@ repository:
     maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
     templates: []
     ## Specify custom or additional autoscaling metrics.
     ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
@@ -501,6 +698,24 @@ repository:
 #         target:
 #           type: AverageValue
 #           averageValue: 10000m
+
+  ## Custom labels for CD/RO repository pods
+  customLabels: {}
+
+  ## Deployment strategy configuration
+  ## type: Recreate (default, safe for artifact storage) or RollingUpdate
+  ## WARNING: RollingUpdate for repository requires:
+  ##   - Multiple replicas (clusteredMode: true)
+  ##   - Shared artifact storage with ReadWriteMany access
+  ##   - Testing of artifact retrieval during rolling updates
+  ## Recreate strategy is recommended for production upgrades.
+  strategy:
+    type: Recreate
+    rollingUpdate:
+      ## Maximum number of pods that can be created above replicas during update
+      maxSurge: 1
+      ## Maximum number of pods that can be unavailable during update
+      maxUnavailable: 0
 
 ### --------------------------------------------
 ### Analytics server configuration section
@@ -524,7 +739,7 @@ analytics:
   ## Kubernetes cluster.
   serviceEndpoint: "flow-analytics.{{ .Release.Namespace }}"
 
-  ## The name of the cluster.
+  ## The name of the Analytic's cluster.
   clusterName:
   ## The number of primary shards that an index should have.
   numberOfShards:
@@ -564,6 +779,7 @@ analytics:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
 
   ## Adds an OpenShift node tuning label to analytics pods, which adjusts
   ## the required value of 'vm.max_map_count'.
@@ -573,14 +789,14 @@ analytics:
 
   ## Additional environment variables to set for cbflow-analytics.
   extraEnvs: []
-  #  extraEnvs:
-  #   - name: FOO
-  #     value: "BAR"
-  #   - name: FOO
-  #     valueFrom:
-  #       secretKeyRef:
-  #         key: FOO
-  #         name: secret-resource
+#  extraEnvs:
+#   - name: FOO
+#     value: "BAR"
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
 
   ## Kubernetes Liveness Probes:
   livenessProbe:
@@ -608,6 +824,21 @@ analytics:
   ## Enable or disable creating an init container for cbflow-analytics volume permissions.
   volumesPermissionsInitContainer:
     enabled: true
+
+  ## Logs storage configuration for cbflow-analytics
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs if not specified)
+    path: /opt/cbflow/logs/analytics
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-analytics-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
   ## Enable or disable registering the analytics server on CD/RO using `setAnalyticsServerConfiguration`.
   ## Set `analytics.autoRegister: false` to prevent the analytics server configuration from being created or updated.
   ## If the analytics server configuration already exists in your deployment, setting this value to `false` has no effect.
@@ -629,10 +860,17 @@ analytics:
     externalRepo:
       ## Enable if you are backing up in Amazon S3 or GCS.
       enabled: false
-      ## Type can be Amazon S3 or GCS.
+      ## Type can be s3, gcs, cloudian, minio, openio.
       type: s3
       # Name of bucket in Amazon S3 or GCS
       bucketName:
+      # endpoint for cloudian,minio, openio
+      endpoint:
+      # endpoint protocol for cloudian, minio, openio options: http, https
+      endpointProtocol:
+      # path style for cloudian, minio, openio
+      pathStyleAccess: true
+
       # base path for backups in Bucket
       basePath: "os-backups"
       ## Use GKE Workload Identity with Kubernetes service account to impersonate a Google Cloud
@@ -659,13 +897,16 @@ analytics:
       ## `kubectl create secret generic gcssasecret --from-file=GCS_SA_KEY=/tmp/gke-credentials.json`
       existingSecret:
       secret:
-        ## Provide *only* if type is AWS S3.
+        ## Provide *only* if type is s3.
         awsAccessKey:
         awsSecretKey:
-        ## Provide *only* if type is GCS.
+        ## Provide *only* if type is gcs.
         gcsSaKey:
+        ## Provide *only* if type is cloudian,minio, openio.
+        accessKey:
+        secretKey:
 
-      ## Region of the AWS S3 or GCS bucket. Example: us-east-1
+      ## Region of the AWS S3, cloudian, minio, openio or GCS bucket. Example: us-east-1
       region:
     ## Custom Pip config file configuration to install pip packages using private PyPi repo
     pipConfig: {}
@@ -681,8 +922,8 @@ analytics:
     ## cbflow-analytics LoadBalancer service annotations for
     ## creating internal LoadBalancer on GCP or AWS.
     annotations:
-  #      networking.gke.io/load-balancer-type: "Internal"
-  #      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+#      networking.gke.io/load-balancer-type: "Internal"
+#      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 
   ## For `analytics.certificates`, you must provide either:
   ## * The certificates for ca, sign, node, admin,
@@ -752,6 +993,9 @@ analytics:
 #     command:
 #       - "/container-command"
 
+  ## Custom labels for CD/RO analytics pods
+  customLabels: {}
+
 ### --------------------------------------------
 ### (LEGACY) Flow DevOps Insight (DOIS/dois) configuration section
 ### ---------------------------------------------
@@ -817,6 +1061,7 @@ dois:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
 
   ## Adds an OpenShift node tuning label to DOIS pods that
   ## configures the 'vm.max_map_count' value required to run Elasticsearch.
@@ -826,14 +1071,14 @@ dois:
 
   ## Additional environment variables to set for cbflow-dois.
   extraEnvs: []
-  #  extraEnvs:
-  #   - name: FOO
-  #     value: "BAR"
-  #   - name: FOO
-  #     valueFrom:
-  #       secretKeyRef:
-  #         key: FOO
-  #         name: secret-resource
+#  extraEnvs:
+#   - name: FOO
+#     value: "BAR"
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
 
   ## DOIS Readiness probe variables:
   healthProbeReadinessPeriodSeconds: 5
@@ -858,6 +1103,8 @@ dois:
   volumesPermissionsInitContainer:
     enabled: true
 
+
+
   ## Enable or disable creating a backup of cbflow-dois data.
   backup:
     ## NOTE: If you change `dois.backup.enabled` for an existing installation,
@@ -874,16 +1121,13 @@ dois:
     externalRepo:
       ## Enable if you are backing up in Amazon S3 or GCS.
       enabled: false
-      ## Type can be s3, gcs, cloudian, minio, openio.
+      ## Type can be Amazon S3 or GCS.
       type: s3
       # Name of bucket in Amazon S3 or GCS
       bucketName:
-      # endpoint for cloudian,minio, openio
-      endpoint:
-      # endpoint protocol for cloudian, minio, openio options: http, https
-      endpointProtocol:
-      # path style for cloudian, minio, openio
-      pathStyleAccess: true
+      ## Use GKE Workload Identity with Kubernetes service account to impersonate a Google Cloud
+      ## Use The AWS IAM roles for service accounts to impersonate access to a S3
+      ## Enable serviceAccountsIdentity or provide IAM or GCS  credentials below
       serviceAccountsIdentity: false
 
       ## For `existingSecret`, either:
@@ -905,16 +1149,13 @@ dois:
       ## `kubectl create secret generic gcssasecret --from-file=GCS_SA_KEY=/tmp/gke-credentials.json`
       existingSecret:
       secret:
-        ## Provide *only* if type is s3.
+        ## Provide *only* if type is AWS S3.
         awsAccessKey:
         awsSecretKey:
-        ## Provide *only* if type is gcs.
+        ## Provide *only* if type is GCS.
         gcsSaKey:
-        ## Provide *only* if type is cloudian,minio, openio.
-        accessKey:
-        secretKey:
 
-      ## Region of the AWS S3, cloudian, minio, openio or GCS bucket. Example: us-east-1
+      ## Region of the AWS S3 or GCS bucket. Example: us-east-1
       region:
     ## Custom Pip config file configuration to install pip packages using private PyPi repo
     pipConfig: {}
@@ -930,8 +1171,8 @@ dois:
     ## cbflow-dois LoadBalancer service annotations for
     ## creating internal LoadBalancer on GCP or AWS.
     annotations:
-  #      networking.gke.io/load-balancer-type: "Internal"
-  #      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+#      networking.gke.io/load-balancer-type: "Internal"
+#      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 
   ## For `dois.certificates`, you must provide either:
   ## * The certificates for ca, sign, node, admin,
@@ -992,6 +1233,9 @@ dois:
 #     command:
 #       - "/container-command"
 
+  ## Custom labels for CD/RO dois pods
+  customLabels: {}
+
 ### --------------------------------------------
 ### Flow bound agent configuration section
 ### ---------------------------------------------
@@ -1005,6 +1249,16 @@ boundAgent:
   replicas: 1
   ## The default loglevel for cbflow-agent.
   logLevel: DEBUG
+
+  ## Complete logging configuration for logging-local.properties.
+  ## If provided, this will override the default logLevel-based configuration.
+  ## This allows you to configure multiple loggers with different log levels.
+  loggingConfig: ""
+  ## Example usage:
+  # loggingConfig: |
+  #   com.electriccloud.commander.agent=DEBUG
+  #   com.electriccloud.commander=INFO
+  #   org.apache=WARN
   flowCredentials:
     ## Enable `serverSecretReference` to re-use flow-server secrets in the agent charts.
     serverSecretReference: true
@@ -1030,6 +1284,8 @@ boundAgent:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
+
   storage:
     volumes:
       agentWorkspace:
@@ -1049,17 +1305,32 @@ boundAgent:
 
   ## Additional environment variables to set for cbflow-agent.
   extraEnvs: []
-  #    - name: FOO
-  #      value: "BAR"
-  #    - name: FOO
-  #      valueFrom:
-  #        secretKeyRef:
-  #          key: FOO
-  #          name: secret-resource
+#    - name: FOO
+#      value: "BAR"
+#    - name: FOO
+#      valueFrom:
+#        secretKeyRef:
+#          key: FOO
+#          name: secret-resource
 
   ## Enable or disable creating init container for volume permissions for cbflow-agent.
   volumePermissions:
     enabled: true
+
+  ## Logs storage configuration for cbflow-bound-agent
+  logs:
+    enabled: false
+    ## Custom logs path (defaults to /opt/cbflow/logs/agent if not specified)
+    path: /opt/cbflow/logs/agent
+    ## Use shared logs storage (from storage.volumes.logsStorage) or component-specific storage
+    useSharedStorage: true
+    ## Component-specific logs storage configuration (used when useSharedStorage: false)
+    storage:
+      name: flow-bound-agent-logs
+      accessMode: ReadWriteOnce
+      storage: 5Gi
+      storageClass:
+      existingClaim: false
 
   ## Specify additional volumes to mount in the cbflow-agent container.
   additionalVolumes: []
@@ -1069,10 +1340,10 @@ boundAgent:
 
   ## Specify additional containers.
   additionalContainers:
-  #   - name: container-name
-  #     image: image-version
-  #     command:
-  #       - "/container-command"
+#   - name: container-name
+#     image: image-version
+#     command:
+#       - "/container-command"
   ## The following configuration enables Role-Based Access Control (RBAC) for managing
   ## bound agents with support for ephemeral scaling. Enable `rbac.create=true`
   ## to create the required service account.
@@ -1088,7 +1359,9 @@ boundAgent:
           resources: [ "pods" ]
           verbs: [ "list", "get" ]
 
-          
+  ## Custom labels for CD/RO bound-agent pods
+  customLabels: {}
+
 ### --------------------------------------------
 ### Flow storage configuration section
 ### ---------------------------------------------
@@ -1139,6 +1412,29 @@ storage:
       ## To use a custom storage class, provide the storageClass name.
       storageClass:
 
+    ## Storage configuration for logs directory, which:
+    ## * Is used by all CDRO components to store logs persistently.
+    ## * Default logs path is /opt/cbflow/logs/ in containers.
+    ## * Can be configured per component using component-specific settings.
+    ##
+    ## To use an existing PVC, set:
+    ## * Set `storage.volumes.logsStorage.name` to your PVC name.
+    ## * Set `existingClaim: true`.
+    logsStorage:
+      enabled: false
+      name: flow-logs
+      accessMode: ReadWriteMany
+      storage: 10Gi
+      ## To use a custom storage class, provide the storageClass name.
+      storageClass:
+      existingClaim: false
+      ## Default logs path in containers
+      logsPath: /opt/cbflow/logs
+      ## Enable subPath expression for pod-specific directories in shared storage
+      useSubPathExpr: false
+      ## Custom subPath expression (defaults to $(POD_NAME) when useSubPathExpr: true)
+      subPathExpr: "$(POD_NAME)"
+
 ### --------------------------------------------
 ### Flow server database configuration section
 ### ---------------------------------------------
@@ -1147,18 +1443,18 @@ storage:
 ## that schema (rw access) - `dbUser` and `dbPassword`.
 
 database:
-  ## URL of you external Db.
-  #  externalEndpoint: "my.db.somewhere.com"
+   ## URL of you external Db.
+#  externalEndpoint: "my.db.somewhere.com"
 
-  ## Use this option if your database resides in the same k8s cluster
-  ## as the flow-server with the notation as <db-service>.<namespace>.
-  ## If deploying into the same namespace, `.<namespace>` can be omitted.
-  #  clusterEndpoint: "<db-service>.<namespace>"
+   ## Use this option if your database resides in the same k8s cluster
+   ## as the flow-server with the notation as <db-service>.<namespace>.
+   ## If deploying into the same namespace, `.<namespace>` can be omitted.
+#  clusterEndpoint: "<db-service>.<namespace>"
 
-  ## Use this option if you have an existing credentials or will deploy the
-  ## secret yourself. The value *must* given in the format:
-  ## existingSecret: server-secrets.yaml::dbSecret
-  #  existingSecret: <my-existing-secret>
+   ## Use this option if you have an existing credentials or will deploy the
+   ## secret yourself. The value *must* given in the format:
+   ## existingSecret: server-secrets.yaml::dbSecret
+#  existingSecret: <my-existing-secret>
   dbName:
   dbUser:
   ## If dbPassword is an empty string, a random 20 characters password is generated.
@@ -1197,13 +1493,13 @@ database:
 ### ---------------------------------------------
 
 flowCredentials:
-  ## Specify either:
-  ## * The secret where the admin user password is stored using
-  ## the 'CBF_SERVER_ADMIN_PASSWORD' key (recommended for production).
-  ## or
-  ## * The adminPassword.
+   ## Specify either:
+   ## * The secret where the admin user password is stored using
+   ## the 'CBF_SERVER_ADMIN_PASSWORD' key (recommended for production).
+   ## or
+   ## * The adminPassword.
   existingSecret:
-  ## If `adminPassword` is an empty string, a random 20 characters password is generated.
+   ## If `adminPassword` is an empty string, a random 20 characters password is generated.
   adminPassword:
 
 ### --------------------------------------------
@@ -1342,16 +1638,46 @@ zookeeper:
     ## Container repository to pull ZooKeeper image from.
     repository: docker.io/cloudbees/cbflow-tools
     ## Zookeeper image tag to pull.
-    tag: "2025.09.0.181816_3.2.191_20250916"
+    tag: "2026.03.0.185227_3.2.235_20260321"
     ## Added Image repository for global values support
     imageRepository: cbflow-tools
   fullnameOverride: zookeeper
   replicaCount: 3
 
+  ## Multi-AZ topology spread constraints
+  ## Example configuration for distributing ZooKeeper across availability zones:
+  # topologySpreadConstraints:
+  #   - maxSkew: 1
+  #     topologyKey: topology.kubernetes.io/zone
+  #     whenUnsatisfiable: DoNotSchedule
+  #     labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: zookeeper
+  topologySpreadConstraints: []
+
   podLabels:
     ownerApp: "cloudbees-flow"
     role: "cluster-coordinator"
     mode: "private"
+
+  ## ZooKeeper environment variables
+  ## For multi-AZ deployments, increase timeouts to account for cross-AZ latency:
+  ## - ZOO_TICK_TIME: 3000-4000 (increase from default 2000)
+  ## - ZOO_INIT_LIMIT: 10-15 (increase from default 5)
+  ## - ZOO_SYNC_LIMIT: 15-20 (increase from default 10)
+  env:
+    JMXAUTH: "false"
+    JMXDISABLE: "false"
+    JMXPORT: 1099
+    JMXSSL: "false"
+    ZOO_PORT: 2181
+    ZOO_INIT_LIMIT: 5
+    ZOO_TICK_TIME: 2000  # Consider 3000-4000 for multi-AZ
+    ZOO_MAX_CLIENT_CNXNS: 60
+    ZOO_SYNC_LIMIT: 10   # Consider 15-20 for multi-AZ
+    ZOO_AUTOPURGE_PURGEINTERVAL: 0
+    ZOO_AUTOPURGE_SNAPRETAINCOUNT: 3
+    ZOO_STANDALONE_ENABLED: false
 
   ## Specify the resources to request for this component.
   resources:
@@ -1419,16 +1745,15 @@ ingress-nginx:
     admissionWebhooks:
       port: 8445
 
-      #    extraArgs:
+#    extraArgs:
       ## Additional log messages that may be useful for debugging.
       ## Shows diff detail about changes in the ingress-nginx configuration.
-      #      v: 2
+#      v: 2
       ## Shows details about the service, Ingress rule, endpoint changes, and
       ## dumps the ingress-nginx configuration in JSON format.
-      #      v: 3
+#      v: 3
       ## Configures NGINX in debug mode
-    #      v: 5
-
+#      v: 5
     config:
       ## Ingress must support long-running requests without resetting the connection.
       ## By default, AWS ELB resets connections after `60` seconds of inactivity. With
@@ -1437,22 +1762,113 @@ ingress-nginx:
       proxy-stream-timeout: "4000s"
       ## `error-log-level` allows you to increase the detail of the error log, which
       ## may be useful for debugging.
-  #      error-log-level: debug
+#      error-log-level: debug
 
   tcp:
     8200: "{{ .Release.Namespace }}/flow-repository:8200"
     8443: "{{ .Release.Namespace }}/flow-server:8443"
     61613: "{{ .Release.Namespace }}/flow-server:61613"
 
-      ##  Additional TCP ports to access DOIS Elasticsearch over the ingress endpoint:
-      #    7800: "{{ .Release.Namespace }}/gateway-external-agent-flow-agents:7800"
-      #    9200: "{{ .Release.Namespace }}/flow-devopsinsight:9200"
+     ##  Additional TCP ports to access DOIS Elasticsearch over the ingress endpoint:
+#    7800: "{{ .Release.Namespace }}/gateway-external-agent-flow-agents:7800"
+#    9200: "{{ .Release.Namespace }}/flow-devopsinsight:9200"
 
-      ##  Additional TCP ports to access Analytics over the ingress endpoint:
-      #    9201: "{{ .Release.Namespace }}/flow-analytics:9201"
+     ##  Additional TCP ports to access Analytics over the ingress endpoint:
+#    9201: "{{ .Release.Namespace }}/flow-analytics:9201"
 
-    ## Additional port to enable external agents to connect to flow-server.
+     ## Additional port to enable external agents to connect to flow-server.
 #    8000: "{{ .Release.Namespace }}/flow-server:8000"
+
+### --------------------------------------------
+### Gateway API configuration section
+### ---------------------------------------------
+
+## Gateway API routes configuration for migrating from ingress-nginx to Gateway API.
+## This chart creates HTTPRoute and TCPRoute resources that attach to a
+## customer-managed Gateway. The Gateway, GatewayClass, TLS certificates,
+## and controller-specific policies are the cluster operator's responsibility.
+##
+## This chart does NOT create the Gateway, GatewayClass, or any controller-specific
+## policies. See the documentation for Gateway configuration examples for
+## popular controllers (NGF, Istio, GKE, AWS ALB, Azure AGC).
+##
+## Requires:
+##   1. Gateway API CRDs pre-installed on the cluster
+##   2. A Gateway resource managed by the cluster operator
+
+gatewayApi:
+  ## Enable creation of HTTPRoute and TCPRoute resources for Gateway API routing.
+  enabled: false
+
+  ## Hostname for Gateway API routes.
+  ## This is the single source of truth for Gateway API — independent of ingress.host.
+  ## REQUIRED when gatewayApi.enabled=true.
+  host: ""
+
+  ## Name of the Gateway resource to attach routes to.
+  ## REQUIRED when gatewayApi.enabled=true.
+  ## This can be any Gateway from any controller — NGF, Istio, GKE, ALB, etc.
+  gatewayName: ""
+
+  ## Namespace of the Gateway. Defaults to Release namespace if empty.
+  gatewayNamespace: ""
+
+  ## HTTPRoute configuration
+  httpRoute:
+    ## Enable creation of the HTTPRoute resource.
+    ## Set to false to use Gateway API for TCP-only routing (e.g. when the web UI
+    ## is behind a separate ingress controller or HTTPRoute is managed externally).
+    ## Default: true
+    enabled: true
+    annotations: {}
+    labels: {}
+    ## Hostnames for the HTTPRoute. Falls back to [gatewayApi.host] if empty.
+    hostnames: []
+
+  ## TCPRoute configuration
+  ## Each TCPRoute references a specific TCP listener on the Gateway via sectionName.
+  ## The customer's Gateway MUST have matching TCP listeners for these ports.
+  ## See NOTES.txt output for Gateway listener requirements.
+  tcpRoute:
+    ## TCPRoute API version. Update this when TCPRoute graduates from experimental.
+    ## Current: v1alpha2 (experimental). Future: v1beta1, v1.
+    apiVersion: "gateway.networking.k8s.io/v1alpha2"
+    annotations: {}
+    labels: {}
+    server:
+      enabled: true
+      ## Must match the name of the TCP listener on the Gateway for port 8443.
+      sectionName: "flow-secure-server"
+    stomp:
+      enabled: true
+      ## Must match the name of the TCP listener on the Gateway for port 61613.
+      sectionName: "flow-stomp"
+    repository:
+      enabled: true
+      ## Must match the name of the TCP listener on the Gateway for port 8200.
+      sectionName: "flow-repository"
+    ## Additional TCPRoutes for optional components (DOIS, Analytics, etc.)
+    additional: []
+    # - name: dois
+    #   sectionName: "flow-dois"    # must match Gateway listener name
+    #   service:
+    #     name: flow-devopsinsight
+    #     port: 9200
+    # - name: analytics
+    #   sectionName: "flow-analytics"    # must match Gateway listener name
+    #   service:
+    #     name: flow-analytics
+    #     port: 9201
+    # - name: external-agent
+    #   sectionName: "gateway-external-agent-flow-agents"    # must match Gateway listener name
+    #   service:
+    #     name: gateway-external-agent-flow-agents
+    #     port: 7800
+    # - name: insecure-server
+    #   sectionName: "flow-insecure-server"    # must match Gateway listener name
+    #   service:
+    #     name: flow-server
+    #     port: 8000
 
 ### --------------------------------------------
 ### Miscellaneous configuration section
@@ -1468,6 +1884,8 @@ sda: false
 mariadb:
   enabled:  false
   image:
+    registry: docker.io
+    repository: bitnamilegacy/mariadb
     tag: "10.11.2-debian-11-r19"
   fullnameOverride: mariadb
   replication:
@@ -1491,72 +1909,72 @@ mariadb:
 ## cloudbees-flow-agent chart configuration to create
 ## an internal gateway agent.
 internalGatewayAgent:
-  enabled: false
-  releaseNamePrefix: gateway-default-agent
-  resourceName: gateway-default-agent
-  ## Number of replicas of this component to create.
-  replicas: 1
-  trustedAgent: false
-  flowCredentials:
-    ## Enable `serverSecretReference` to re-use flow-server secrets in agents chart.
-    serverSecretReference: true
-
-  ## Horizontal Pod Autoscaling configuration for internalGatewayAgent.
-  ## IMPORTANT: This is only supported when `clusteredMode: true`.
-  autoscaling:
     enabled: false
-    minReplicas: 1
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
-  gateway:
-    ## Recognize as internal gateway agent.
-    enabled: true
+    releaseNamePrefix: gateway-default-agent
+    resourceName: gateway-default-agent
+    ## Number of replicas of this component to create.
+    replicas: 1
+    trustedAgent: false
+    flowCredentials:
+      ## Enable `serverSecretReference` to re-use flow-server secrets in agents chart.
+      serverSecretReference: true
+
+   ## Horizontal Pod Autoscaling configuration for internalGatewayAgent.
+   ## IMPORTANT: This is only supported when `clusteredMode: true`.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 2
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    gateway:
+      ## Recognize as internal gateway agent.
+      enabled: true
 
 ## cloudbees-flow-agent chart configurations used for creating an
 ## external gateway agent.
 externalGatewayAgent:
-  enabled: false
-  releaseNamePrefix: gateway-external-agent
-  resourceName: gateway-external-agent
-  ## Number of replicas of this component to create.
-  replicas: 1
-  trustedAgent: false
-  zoneName: external
-  service:
-    ## External DNS hostname external agents use to communicate
-    ## with the external gateway agent
-    publicHostName:
-  ## Enabling `externalService` creates a Load Balancer Kubernetes service named `<prefix>-flow-agents-external`.
-  ## If `externalGatewayAgent.service.publicHostName` above is configured with a DNS Endpoint (DNS Entry added for LB Endpoint), an
-  ## External Gateway Agent with the specified Agent Host Name is automatically created.
-  ## The port can be set to ports other than 7800. The load balancer will route any requests
-  ## to the specified port to the internal service on port 7800.
-  externalService:
     enabled: false
-    port: 7800
+    releaseNamePrefix: gateway-external-agent
+    resourceName: gateway-external-agent
+    ## Number of replicas of this component to create.
+    replicas: 1
+    trustedAgent: false
+    zoneName: external
+    service:
+      ## External DNS hostname external agents use to communicate
+      ## with the external gateway agent
+      publicHostName:
+    ## Enabling `externalService` creates a Load Balancer Kubernetes service named `<prefix>-flow-agents-external`.
+    ## If `externalGatewayAgent.service.publicHostName` above is configured with a DNS Endpoint (DNS Entry added for LB Endpoint), an
+    ## External Gateway Agent with the specified Agent Host Name is automatically created.
+    ## The port can be set to ports other than 7800. The load balancer will route any requests
+    ## to the specified port to the internal service on port 7800.
+    externalService:
+      enabled: false
+      port: 7800
 
-  ## Configure gateway using external gateway agent.
-  gateway:
-    ## Configure gateway using this agent.
-    enabled: true
-    ## Name of the gateway to create.
-    name: external
-    ## Name of the gateway agent to pair with as gateway resource 2.
-    pairedResourceName: gateway-default-agent
+    ## Configure gateway using external gateway agent.
+    gateway:
+      ## Configure gateway using this agent.
+      enabled: true
+      ## Name of the gateway to create.
+      name: external
+      ## Name of the gateway agent to pair with as gateway resource 2.
+      pairedResourceName: gateway-default-agent
 
-  flowCredentials:
-    ## Enable `serverSecretReference` to re-use flow-server secrets in agents chart.
-    serverSecretReference: true
+    flowCredentials:
+      ## Enable `serverSecretReference` to re-use flow-server secrets in agents chart.
+      serverSecretReference: true
 
-  ## Horizontal Pod Autoscaling configuration for externalGatewayAgent.
-  ## This is only supported when `clusteredMode: true`.
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+    ## Horizontal Pod Autoscaling configuration for externalGatewayAgent.
+    ## This is only supported when `clusteredMode: true`.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 2
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
 
 gitops:
   enabled: false


### PR DESCRIPTION
[POST-RELEASE] Update CB helm CDRO examples configuration files v2026.03

CDRO-13616 - [POST-RELEASE] Update CB helm CDRO examples configuration files v2026.03

This commit updates cloudbees-cd/kubernetes/values.yaml with changes for v2026.03 release including:
- Image tags updated from 2025.09.0.181816_3.2.191_20250916 to 2026.03.0.185227_3.2.235_20260321
- New configuration options added (loggingConfig, topologySpreadConstraints, terminationGracePeriodSeconds, additionalInitContainers, logs storage)
- Readiness probe initialDelaySeconds increased from 60 to 90
- Formatting and indentation improvements throughout


This commit updates the image tags from version 2025.09.0.181816_3.2.191_20250916 to 2026.03.0.185227_3.2.235_20260321 in:
- cloudbees-cd/kubernetes/cloudbees-cd-agent-defaults.yaml
- cloudbees-cd/kubernetes/cloudbees-cd-defaults.yaml (including zookeeper image tag) 